### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "./rentry"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # rentry
 
 <a href="https://rentry.co/"><img width="110" height="110" src="https://rentry.co/static/logo-border-fit.png" align="right" alt="rentry.co markdown pastebin"></a>
+[![Run on Repl.it](https://repl.it/badge/github/radude/rentry)](https://repl.it/github/radude/rentry)
 
 [Rentry.co](https://rentry.co) is markdown-powered pastebin/publishing service with preview, custom urls and editing. 
 


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@Mosrod/rentry).